### PR TITLE
Updated Recovery::toJson docblock to return type string. 

### DIFF
--- a/src/Recovery.php
+++ b/src/Recovery.php
@@ -207,9 +207,9 @@ class Recovery
     }
 
     /**
-     * Get a json of recovery codes.
+     * Get recovery codes as json string.
      *
-     * @return array
+     * @return string
      */
     public function toJson()
     {


### PR DESCRIPTION
The return type of method Recovery::toJson is currently set as an array. I have changed this to string as json_decode returns a string.
This was causing issues in PHPUnit for me. 
I don't know how this versioning stuff works, so let me know.

Great library btw.
Cheers.